### PR TITLE
patch: add missing typing-extensions dependency

### DIFF
--- a/charmcraftlocal/_main.py
+++ b/charmcraftlocal/_main.py
@@ -73,7 +73,7 @@ class State:
         if value == self._verbose:
             return
         self._verbose = value
-        log_format = "\[charmcraftlocal] {levelname} {message}"
+        log_format = r"\[charmcraftlocal] {levelname} {message}"
         if value:
             log_format = "{asctime} " + log_format
             logger.setLevel(logging.DEBUG)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "tomli>=2.2.1",
     "charm-refresh-build-version>=0.4.0",
     "pyyaml>=6.0.2",
+    "typing-extensions>=4.15.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes:

```
$ uv venv -p 3.12
Using CPython 3.12.3 interpreter at: /usr/bin/python3.12
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate.fish
$ uv pip install charmcraftlocal                                                                   
Resolved 20 packages in 657ms                                                                                                                                  
Prepared 12 packages in 245ms
Installed 20 packages in 14ms                                                                                                                                  
 + annotated-doc==0.0.4    
 + certifi==2026.1.4        
 + charm-refresh-build-version==0.4.0
 + charmcraftlocal==0.3.1
 + charset-normalizer==3.4.4         
 + click==8.3.1                                                                                                                                                
 + dunamai==1.25.0          
 + idna==3.11  
 + markdown-it-py==4.0.0
 + mdurl==0.1.2
 + packaging==26.0      
 + pygments==2.19.2
 + pyyaml==6.0.3  
 + requests==2.32.5
 + rich==14.3.2 
 + shellingham==1.5.4
 + tomli==2.4.0
 + tomlkit==0.14.0   
 + typer==0.21.2
 + urllib3==2.6.3 
$ uv run charmcraftlocal pack
/home/ubuntu/Projects/Canonical/playground/.venv/lib/python3.12/site-packages/charmcraftlocal/_main.py:76: SyntaxWarning: invalid escape sequence '\['
  log_format = "\[charmcraftlocal] {levelname} {message}"    
Traceback (most recent call last):                                                                                                                             
  File "/home/ubuntu/Projects/Canonical/playground/.venv/bin/charmcraftlocal", line 4, in <module>                                                    
    from charmcraftlocal._main import app                
  File "/home/ubuntu/Projects/Canonical/playground/.venv/lib/python3.12/site-packages/charmcraftlocal/_main.py", line 15, in <module>
    import typing_extensions                                                                                                                                                                                                                                                                                                  
ModuleNotFoundError: No module named 'typing_extensions'
```