### PR TITLE
patch: Fix install from git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ ccl = "charmcraftlocal._main:app"
 charmcraftlocal = "charmcraftlocal._main:app"
 
 [tool.poetry]
-version = "0.0.0"  # Overriden by poetry-dynamic-versioning
 requires-poetry = ">=2.0"
+version = "0.0.0"  # Overriden by poetry-dynamic-versioning
 
 [tool.poetry.requires-plugins]
 poetry-dynamic-versioning = { version = ">=1.0.0,<2.0.0", extras = ["plugin"] }


### PR DESCRIPTION
Installation from git was marked as dirty (and failed) because pyproject.toml was reformatted

Might be related to https://github.com/mtkennerly/poetry-dynamic-versioning/issues/223